### PR TITLE
v2.6: YGOMobile onboarding dialog + persistent spectate hint

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,8 +34,8 @@ android {
         applicationId "xjunz.tool.mycard"
         minSdk 23
         targetSdk 37
-        versionCode 25
-        versionName "2.4"
+        versionCode 27
+        versionName "2.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         signingConfig signingConfigs.debug

--- a/app/src/main/java/xjunz/tool/mycard/App.kt
+++ b/app/src/main/java/xjunz/tool/mycard/App.kt
@@ -7,6 +7,7 @@ import android.util.Printer
 import androidx.core.content.ContextCompat
 import top.xjunz.returntransitionpatcher.ReturnTransitionPatcher
 import xjunz.tool.mycard.info.PlayerInfoManager
+import xjunz.tool.mycard.main.account.AccountManager
 import xjunz.tool.mycard.outer.GlobalCrashHandler
 import java.io.File
 
@@ -39,6 +40,7 @@ class App : Application() {
         GlobalCrashHandler.init()
         ReturnTransitionPatcher.patchAll(this)
         app = this
+        AccountManager.initIfNeeded()
 
         val dataDir = ContextCompat.getDataDir(this)
         val legacyConfig = File(dataDir, "/shared_prefs/config.xml")

--- a/app/src/main/java/xjunz/tool/mycard/game/GameLauncher.kt
+++ b/app/src/main/java/xjunz/tool/mycard/game/GameLauncher.kt
@@ -2,8 +2,10 @@ package xjunz.tool.mycard.game
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import androidx.core.content.edit
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import xjunz.tool.mycard.Apis
@@ -16,6 +18,7 @@ import xjunz.tool.mycard.ktx.toast
 import xjunz.tool.mycard.main.account.AccountManager
 import xjunz.tool.mycard.main.account.Generator
 import xjunz.tool.mycard.main.account.LoginDialog
+import xjunz.tool.mycard.main.settings.Configs
 import xjunz.tool.mycard.model.Duel
 import xjunz.tool.mycard.model.MatchResult
 
@@ -26,6 +29,8 @@ import xjunz.tool.mycard.model.MatchResult
 object GameLauncher {
 
     private const val ACTION_LAUNCH_YGO_MOBILE_GAME = "ygomobile.intent.action.GAME"
+    private const val SP_NAME_GAME = "game"
+    private const val SP_KEY_YGO_INTRO_SEEN_INSTALL_TIME = "ygo_mobile_intro_seen_install_time"
 
     private inline val token get() = Generator.generateToken(AccountManager.reqU16Secret())
 
@@ -50,7 +55,11 @@ object GameLauncher {
     fun launch(username: String, host: String, port: Int, roomId: String) {
         runCatching {
             val intent = Intent(ACTION_LAUNCH_YGO_MOBILE_GAME).apply {
-                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+                // FLAG_ACTIVITY_CLEAR_TASK forces YGOMobile's MainActivity to cold-start every
+                // time, gating our extras behind its async ResCheckTask and showing a black
+                // screen until that completes. NEW_TASK alone lets a warm task receive the
+                // intent via onNewIntent, where extras are dispatched immediately.
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 putExtra("host", host)
                 putExtra("port", port)
                 putExtra("user", username)
@@ -76,31 +85,87 @@ object GameLauncher {
             toast(R.string.pls_login_first)
             return
         }
-        val loading = activity.showLoadingDialog(R.string.connecting_to_server)
-        val job = activity.lifecycleScope.launch {
-            try {
+        showFirstTimeYgoHintIfNeeded(activity) {
+            val loading = activity.showLoadingDialog(R.string.connecting_to_server)
+            val job = activity.lifecycleScope.launch {
                 try {
-                    AccountManager.refreshU16Secret()
-                } catch (e: AccountManager.AuthExpiredException) {
-                    AccountManager.logout()
-                    toast(R.string.session_expired)
-                    LoginDialog().doOnSuccess {
-                        duel.spectateCheckLogin(activity)
-                    }.show(activity.supportFragmentManager, "login")
-                    return@launch
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    // Network or transient server error: fall back to the cached secret.
-                    // The server tolerates the previous rotation, so this still works briefly.
-                    e.printStackTrace()
+                    try {
+                        AccountManager.refreshU16Secret()
+                    } catch (e: AccountManager.AuthExpiredException) {
+                        AccountManager.logout()
+                        toast(R.string.session_expired)
+                        LoginDialog().doOnSuccess {
+                            duel.spectateCheckLogin(activity)
+                        }.show(activity.supportFragmentManager, "login")
+                        return@launch
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // Network or transient server error: fall back to the cached secret.
+                        // The server tolerates the previous rotation, so this still works briefly.
+                        e.printStackTrace()
+                    }
+                    spectateAthleticDuel(duel.id)
+                } finally {
+                    loading.dismiss()
                 }
-                spectateAthleticDuel(duel.id)
-            } finally {
-                loading.dismiss()
             }
+            loading.setOnCancelListener { job.cancel() }
         }
-        loading.setOnCancelListener { job.cancel() }
+    }
+
+    /**
+     * Show a one-time onboarding dialog before the first GAME-intent launch. YGOMobile's
+     * MainActivity gates the intent behind an async ResCheckTask that fails quietly when
+     * first-run init has not been performed by LogoActivity, leaving the user on a black
+     * screen. Letting the user open YGOMobile once first sidesteps that.
+     *
+     * The dismissal flag is keyed to YGOMobile's [PackageInfo.firstInstallTime] so a
+     * reinstall re-arms the hint, and is only persisted when the user picks "Open
+     * YGOMobile first" — that's the only branch we know guarantees first-run init.
+     */
+    private fun showFirstTimeYgoHintIfNeeded(
+        activity: FragmentActivity,
+        onProceed: () -> Unit,
+    ) {
+        val prefs = app.sharedPrefsOf(SP_NAME_GAME)
+        val pm = activity.packageManager
+        val pkgName = Intent(ACTION_LAUNCH_YGO_MOBILE_GAME)
+            .resolveActivity(pm)?.packageName
+        val installTime = pkgName?.let {
+            runCatching { pm.getPackageInfo(it, 0).firstInstallTime }.getOrNull()
+        } ?: 0L
+        if (installTime > 0L &&
+            prefs.getLong(SP_KEY_YGO_INTRO_SEEN_INSTALL_TIME, 0L) == installTime
+        ) {
+            onProceed()
+            return
+        }
+        MaterialAlertDialogBuilder(activity)
+            .setTitle(R.string.first_time_ygo_title)
+            .setMessage(R.string.first_time_ygo_message)
+            .setCancelable(true)
+            .setNegativeButton(R.string.open_ygo_first) { _, _ ->
+                Configs.firstTimeYgoHintRead = true
+                if (installTime > 0L) {
+                    prefs.edit {
+                        putLong(SP_KEY_YGO_INTRO_SEEN_INSTALL_TIME, installTime)
+                    }
+                }
+                val launchIntent = pkgName?.let { pm.getLaunchIntentForPackage(it) }
+                if (launchIntent != null) {
+                    activity.startActivity(launchIntent)
+                } else {
+                    longToast(R.string.no_game_launcher_found)
+                }
+            }
+            .setPositiveButton(R.string.continue_anyway) { _, _ ->
+                Configs.firstTimeYgoHintRead = true
+                // Intentionally don't persist the install-time flag here: if init was never
+                // done, the launch will black-screen and the dialog should re-arm next time.
+                onProceed()
+            }
+            .show()
     }
 
     fun MatchResult.launchGameCheckLogin(activity: FragmentActivity) {

--- a/app/src/main/java/xjunz/tool/mycard/main/DuelListFragment.kt
+++ b/app/src/main/java/xjunz/tool/mycard/main/DuelListFragment.kt
@@ -106,6 +106,7 @@ class DuelListFragment : Fragment() {
                 MaterialFadeThrough(), target = binding.connectivityPrompt
             )
             binding.connectivityPrompt.isVisible = !it
+            shouldShowSpectateHintHeader = computeShouldShowSpectateHintHeader()
             if (Configs.hasFilterApplied) {
                 if (!it && viewModel.isServiceBound()
                     && viewModel.monitorState.value == State.CONNECTED
@@ -124,6 +125,11 @@ class DuelListFragment : Fragment() {
         binding.btnClearAll.setOnClickListener {
             viewModel.monitorService.clearAllIfOutOfDate()
             shouldShowHeader = false
+        }
+        binding.cardSpectateHint.isVisible = shouldShowSpectateHintHeader
+        binding.btnCloseSpectateHint.setOnClickListener {
+            Configs.shouldShowSpectateHintHeader = false
+            shouldShowSpectateHintHeader = false
         }
         viewModel.isServiceBound.observe(viewLifecycleOwner) {
             if (it) {
@@ -295,36 +301,52 @@ class DuelListFragment : Fragment() {
             updateHeader()
         }
 
+    private var shouldShowSpectateHintHeader: Boolean = false
+        set(value) {
+            if (value == field) return
+            field = value
+            updateHeader()
+        }
+
+    private fun computeShouldShowSpectateHintHeader(): Boolean {
+        return Configs.firstTimeYgoHintRead
+                && Configs.shouldShowSpectateHintHeader
+                && viewModel.hasDataShown.value == true
+    }
+
     private fun updateHeader() {
         binding.topBar.beginDelayedTransition()
+        binding.cardSpectateHint.isVisible = shouldShowSpectateHintHeader
+        binding.cardHeader.isVisible = shouldShowHeader
         if (shouldShowHeader) {
-            binding.cardHeader.isVisible = true
-            binding.cardHeader.doOnPreDraw {
-                binding.rvDuel.updatePadding(top = it.bottom + 4.dp)
-            }
             val timestamp = viewModel.monitorService.lastUpdateTimestamp
             if (timestamp > 0 && viewModel.monitorService.duelList.isNotEmpty()) {
                 binding.tvTimelinessTip.text =
                     R.string.format_last_update_time.format(timestamp.formatToDate())
             }
-        } else {
-            binding.cardHeader.isVisible = false
-            binding.rvDuel.updatePadding(top = binding.cvTitle.bottom)
         }
     }
 
     private fun initRecyclerViewAndTopBar(
         rv: RecyclerView = binding.rvDuel, topBar: View = binding.topBar
     ) {
-        var paddingTop = -1
+        var bottomPaddingApplied = false
         rv.applySystemInsets { _, insets ->
             topBar.updatePadding(top = insets.top)
-            if (paddingTop == -1) {
-                paddingTop = topBar.height + insets.top
-                rv.updatePadding(top = paddingTop)
+            if (!bottomPaddingApplied) {
+                bottomPaddingApplied = true
                 // Make an extra padding to avoid the bottom bar overlapping items while the recyclerview
                 // is not even scrollable.
                 rv.updatePadding(bottom = insets.bottom + viewModel.bottomBarHeight.value!!)
+            }
+        }
+        // Keep the RV's top padding in sync with topBar's current height so children
+        // appearing/disappearing inside the AppBarLayout (cardSpectateHint, cardHeader)
+        // never overlap the first row. The listener fires within the same layout pass
+        // before the RV is laid out, so items position with the new padding immediately.
+        topBar.addOnLayoutChangeListener { v, _, _, _, _, _, _, _, _ ->
+            if (rv.paddingTop != v.height) {
+                rv.updatePadding(top = v.height)
             }
         }
         rv.addOnScrollListener(object : RecyclerView.OnScrollListener() {
@@ -333,6 +355,11 @@ class DuelListFragment : Fragment() {
                 viewModel.shouldShowBottomBar.value = dy < 0
             }
         })
+    }
+
+    override fun onResume() {
+        super.onResume()
+        shouldShowSpectateHintHeader = computeShouldShowSpectateHintHeader()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/xjunz/tool/mycard/main/MainActivity.kt
+++ b/app/src/main/java/xjunz/tool/mycard/main/MainActivity.kt
@@ -74,10 +74,8 @@ class MainActivity : AppCompatActivity() {
                     this, android.Manifest.permission.POST_NOTIFICATIONS
                 ) != PackageManager.PERMISSION_GRANTED
             ) {
-                registerForActivityResult(ActivityResultContracts.RequestPermission()) {
-                    if (!it) {
-                        finish()
-                    }
+                registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+                    if (granted) bindMonitorService() else finish()
                 }.launch(android.Manifest.permission.POST_NOTIFICATIONS)
             } else {
                 bindMonitorService()

--- a/app/src/main/java/xjunz/tool/mycard/main/settings/Configs.kt
+++ b/app/src/main/java/xjunz/tool/mycard/main/settings/Configs.kt
@@ -62,6 +62,14 @@ object Configs {
             configSharedPrefs.edit { putBoolean(SP_KEY_MINE_AS_HOME, value) }
         }
 
+    private const val SP_KEY_FIRST_TIME_YGO_HINT_READ = "first_time_ygo_hint_read"
+
+    var firstTimeYgoHintRead: Boolean
+        get() = configSharedPrefs.getBoolean(SP_KEY_FIRST_TIME_YGO_HINT_READ, false)
+        set(value) {
+            configSharedPrefs.edit { putBoolean(SP_KEY_FIRST_TIME_YGO_HINT_READ, value) }
+        }
+
     private const val SP_KEY_DUEL_LIST_FILTER = "duel_list_filter"
 
     private val EMPTY_DUEL_LIST_FILTER_CRITERIA = DuelListFilterCriteria()
@@ -100,6 +108,7 @@ object Configs {
         shouldShowHistoryPlayerNameBalloon = true
         shouldShowFilterBalloon = true
         shouldShowBackToTopBalloon = true
+        shouldShowSpectateHintHeader = true
     }
 
     private const val SP_KEY_SHOW_FILTER_BALLOON = "show_filter_balloon"
@@ -132,5 +141,15 @@ object Configs {
             balloonShardPrefs.edit {
                 putBoolean(SP_KEY_SHOW_HISTORY_PLAYER_NAME_BALLOON, value)
             }
+        }
+
+    private const val SP_KEY_SHOW_SPECTATE_HINT_HEADER = "show_spectate_hint_header"
+
+    var shouldShowSpectateHintHeader: Boolean
+        get() {
+            return balloonShardPrefs.getBoolean(SP_KEY_SHOW_SPECTATE_HINT_HEADER, true)
+        }
+        set(value) {
+            balloonShardPrefs.edit { putBoolean(SP_KEY_SHOW_SPECTATE_HINT_HEADER, value) }
         }
 }

--- a/app/src/main/java/xjunz/tool/mycard/monitor/push/DuelFilterCriteria.kt
+++ b/app/src/main/java/xjunz/tool/mycard/monitor/push/DuelFilterCriteria.kt
@@ -20,7 +20,7 @@ import xjunz.tool.mycard.monitor.push.DuelFilterCriteria.PlayerCriteria
  */
 @Serializable
 data class DuelFilterCriteria(
-    @IntRange(from = 0)
+    @param:IntRange(from = 0)
     var pushDelayInMinute: Int = 0,
     var onePlayerCriteria: PlayerCriteria? = null,// one player criteria should not equal to..
     var theOtherPlayerCriteria: PlayerCriteria? = null,//..the other player criteria.

--- a/app/src/main/res/layout/fragment_duel.xml
+++ b/app/src/main/res/layout/fragment_duel.xml
@@ -64,6 +64,45 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <com.google.android.material.card.MaterialCardView
+            android:id="@+id/card_spectate_hint"
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/spacing_unit"
+            android:layout_marginBottom="@dimen/spacing_unit"
+            app:cardBackgroundColor="?colorPrimary"
+            app:cardCornerRadius="@dimen/spacing_normal">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingStart="@dimen/spacing_normal"
+                android:paddingEnd="@dimen/spacing_unit"
+                android:paddingVertical="12dp">
+
+                <TextView
+                    android:id="@+id/tv_spectate_hint"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/spectate_header_hint"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                    android:textColor="?colorOnPrimary" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_close_spectate_hint"
+                    style="@style/Widget.Material3.Button.IconButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/close"
+                    app:icon="@drawable/ic_baseline_close_24"
+                    app:iconTint="?colorOnPrimary" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
             android:id="@+id/card_header"
             style="@style/Widget.Material3.CardView.Elevated"
             android:layout_width="match_parent"

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -29,6 +29,11 @@
     <string name="pls_login_first">观战前请先登录</string>
     <string name="session_expired">登录已过期，请重新登录</string>
     <string name="connecting_to_server">正在连接服务器…</string>
+    <string name="first_time_ygo_title">启动 YGO Mobile</string>
+    <string name="first_time_ygo_message">YGO Mobile 需要先在后台运行才能直接打开房间。如果还没打开过 YGO Mobile，请先打开一次再回来观战。\n\n另外：观战结束时请通过YGO Mobile内的菜单退出，不要从最近任务里把对局划掉，否则会导致观战异常。</string>
+    <string name="open_ygo_first">先打开 YGO Mobile</string>
+    <string name="continue_anyway">继续观战</string>
+    <string name="spectate_header_hint">观战前，请确保YGO Mobile在后台运行。\n离开观战请通过YGO Mobile内的菜单正常退出。从最近任务列表划掉对局可能导致下次观战异常。</string>
     <string name="no_internet">无网络</string>
     <string name="format_last_update_time">对局列表可能已过时。上次更新时间：%s</string>
     <string name="server_error">服务器错误</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -30,7 +30,7 @@
     <string name="session_expired">登录已过期，请重新登录</string>
     <string name="connecting_to_server">正在连接服务器…</string>
     <string name="first_time_ygo_title">启动 YGO Mobile</string>
-    <string name="first_time_ygo_message">YGO Mobile 需要先在后台运行才能直接打开房间。如果还没打开过 YGO Mobile，请先打开一次再回来观战。\n\n另外：观战结束时请通过YGO Mobile内的菜单退出，不要从最近任务里把对局划掉，否则会导致观战异常。</string>
+    <string name="first_time_ygo_message">YGO Mobile 需要先在后台运行才能直接打开房间。如果没有，请先打开一次再回来观战。\n\n另外：观战结束时请通过YGO Mobile内的菜单退出，不要从最近任务里把对局划掉，否则会导致观战异常。</string>
     <string name="open_ygo_first">先打开 YGO Mobile</string>
     <string name="continue_anyway">继续观战</string>
     <string name="spectate_header_hint">观战前，请确保YGO Mobile在后台运行。\n离开观战请通过YGO Mobile内的菜单正常退出。从最近任务列表划掉对局可能导致下次观战异常。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <string name="app_name">MyCard YGO Assistant</string>
     <string name="duel_list">Duels</string>
-    <string name="monitor_service_is_running">The monitor service is running…</string>
-    <string name="rank">Athletic Rank</string>
+    <string name="monitor_service_is_running">Monitor service is running…</string>
+    <string name="rank">Athletic rank</string>
     <string name="sort">Sort</string>
     <string name="spectate">Spectate</string>
     <string name="restart_service">Restart Service</string>
@@ -18,107 +18,112 @@
     <string name="field_cannot_be_null">This field cannot be empty</string>
     <string name="input_too_short">Your input is too short</string>
     <string name="input_is_empty">Your input is empty</string>
-    <string name="log_in_succeeded">Log in succeeded!</string>
-    <string name="log_in_failed">Log in failed due to %s </string>
-    <string name="no_game_launcher_found">No app to launch the game, try out YGO Mobile!</string>
-    <string name="format_unexpected_error">Unexpected error occurred: %s</string>
-    <string name="format_error_code">Error occurred: %d</string>
-    <string name="username_or_pwd_incorrect">Either the username or password is incorrect</string>
-    <string name="request_timed_out">Request Timed Out</string>
+    <string name="log_in_succeeded">Logged in successfully</string>
+    <string name="log_in_failed">Login failed: %s</string>
+    <string name="no_game_launcher_found">Cannot launch the game. Please install YGO Mobile.</string>
+    <string name="format_unexpected_error">An error occurred: %s</string>
+    <string name="format_error_code">An error occurred (%d)</string>
+    <string name="username_or_pwd_incorrect">Incorrect username or password</string>
+    <string name="request_timed_out">Request timed out</string>
     <string name="pls_login_first">Please log in before spectating</string>
     <string name="session_expired">Session expired, please log in again</string>
     <string name="connecting_to_server">Connecting to server…</string>
-    <string name="no_internet">No Internet</string>
-    <string name="format_last_update_time">Note: duels might be out-of-date. \nLast update time: %s</string>
-    <string name="format_timeliness">Last update time: %s</string>
-    <string name="server_error">Server Error</string>
-    <string name="network_error_or_server_error">Network error or server error</string>
-    <string name="network_error">Network Error</string>
-    <string name="unknown_error">Unknown Error</string>
-    <string name="too_frequent">Requests are too frequent</string>
+    <string name="first_time_ygo_title">Launch YGOMobile</string>
+    <string name="first_time_ygo_message">YGOMobile must already be running in the background before a room can be opened directly. If you haven\'t opened YGOMobile yet, please launch it once and then come back to spectate.\n\nAlso: when a duel ends, exit through YGOMobile\'s in-game menu. Swiping it away from Recents can leave stale state and break the next spectate.</string>
+    <string name="open_ygo_first">Open YGOMobile first</string>
+    <string name="continue_anyway">Spectate anyway</string>
+    <string name="spectate_header_hint">Before spectating, make sure YGOMobile is running in the background. When done, exit through YGOMobile\'s in-game menu — swiping the duel away from Recents may break the next spectate.</string>
+    <string name="no_internet">No internet</string>
+    <string name="format_last_update_time">Duel list may be out of date.\nLast updated: %s</string>
+    <string name="format_timeliness">Last updated: %s</string>
+    <string name="server_error">Server error</string>
+    <string name="network_error_or_server_error">Network or server error</string>
+    <string name="network_error">Network error</string>
+    <string name="unknown_error">Unknown error</string>
+    <string name="too_frequent">Too many requests</string>
     <string name="connecting_to_to_server">Connecting to the server…</string>
-    <string name="service_is_idle">Service is not yet started</string>
+    <string name="service_is_idle">Service is not running</string>
     <string name="newcomer">Newcomer</string>
 
-    <string name="developer">The Developer</string>
+    <string name="developer">Developer</string>
 
     <string name="all_win_lose_draw">All/Win/Lose/Draw</string>
     <string name="win_rate">Win Rate</string>
     <string name="tags">Tags</string>
 
-    <string name="format_duel_ended_unknown">Ended at %s.</string>
-    <string name="format_duel_ended">Started at %s and ended at %s. Has lasted for %s.</string>
-    <string name="format_duel_in_progress">Started at %s and has lasted for %s.</string>
+    <string name="format_duel_ended_unknown">Ended at %s</string>
+    <string name="format_duel_ended">Started at %s, ended at %s. Lasted %s.</string>
+    <string name="format_duel_in_progress">Started at %s, running for %s</string>
     <string name="format_min_sec">%d m %02d s</string>
     <string name="format_sec">%d seconds</string>
-    <string name="connection_is_lost">The connection is lost</string>
-    <string name="duel_state_unknown">The duel state is unknown</string>
+    <string name="connection_is_lost">Connection lost</string>
+    <string name="duel_state_unknown">Duel state unknown</string>
     <string name="format_duel_start">Started at %s</string>
     <string name="follow">Follow</string>
-    <string name="format_follow_player">Player ⌈%s⌋ is followed</string>
-    <string name="format_unfollow_player">Player ⌈%s⌋ is unfollowed</string>
-    <string name="format_prompt_unfollow_player">Are you sure to unfollow player ⌈%s⌋?</string>
+    <string name="format_follow_player">Now following player ⌈%s⌋</string>
+    <string name="format_unfollow_player">Unfollowed player ⌈%s⌋</string>
+    <string name="format_prompt_unfollow_player">Are you sure you want to unfollow player ⌈%s⌋?</string>
     <string name="prompt">Prompt</string>
-    <string name="tip_stop_service">Are you sure to stop the service? </string>
-    <string name="add_tag">New Tag</string>
+    <string name="tip_stop_service">Are you sure you want to stop the service?</string>
+    <string name="add_tag">Add tag</string>
     <string name="edit_tag">Edit this tag</string>
     <string name="rename_to">Rename to</string>
-    <string name="delete_tag">Delete this tag</string>
+    <string name="delete_tag">Remove this tag</string>
     <string name="hint_add_tag">Add a tag to this player</string>
-    <string name="tag_existed">This tag has already existed</string>
+    <string name="tag_existed">This tag already exists</string>
     <string name="tag_illegal_char">Contains illegal character \'|\'</string>
     <string name="hint_tag_name">Such as a deck name</string>
-    <string name="tag_is_blank">The tag should not be blank</string>
-    <string name="no_more_tags">The max tag count is 6, please try to delete some tags.</string>
+    <string name="tag_is_blank">Tag cannot be blank</string>
+    <string name="no_more_tags">Max tag count is %d. Please remove some tags first.</string>
     <string name="unfollow">Unfollow</string>
     <string name="dismiss">Dismiss</string>
     <string name="clear_all">Clear All</string>
-    <string name="no_duels_now">No Duels Now</string>
-    <string name="logging_in">Verifying your credential…</string>
+    <string name="no_duels_now">No duels right now</string>
+    <string name="logging_in">Verifying credentials…</string>
     <string name="feedback">Feedback</string>
     <string name="restart_app">Restart App</string>
     <string name="oops_app_crashed">Oops! App crashed…</string>
 
     <string name="open_via">Open via</string>
-    <string name="service_is_stopped">Service is stopped</string>
-    <string name="configurations">Configurations</string>
+    <string name="service_is_stopped">Service stopped</string>
+    <string name="configurations">Configuration</string>
     <string name="disable_notifications">Disable all notifications</string>
     <string name="delete">Delete</string>
     <string name="edit">Edit</string>
-    <string name="prompt_delete_criteria">Are you sure to delete this criteria?</string>
+    <string name="prompt_delete_criteria">Are you sure you want to delete this criterion?</string>
     <string name="add_criteria">Add Criteria</string>
     <string name="duel_push_criteria">Duel Push Criteria</string>
-    <string name="pin_duel_with_following">Pin duels involving any followed duelist.</string>
-    <string name="duel_is_ended">The duel is ended</string>
+    <string name="pin_duel_with_following">Pin duels involving a followed player</string>
+    <string name="duel_is_ended">Duel ended</string>
     <string name="discard">Discard</string>
     <string name="required_tag">Required Tag</string>
     <string name="rank_upper_bound">Rank upper bound</string>
     <string name="rank_lower_bound">Rank lower bound</string>
     <string name="criteria_for_one_player">Criteria for one player</string>
     <string name="criteria_for_the_other_player">Criteria for the other player</string>
-    <string name="requires_followed_duelist">Requires involving at least one followed duelist</string>
-    <string name="unlimited_criteria">Invalid criteria: all duels match this criteria.</string>
-    <string name="invalid_rank_range">The rank upper bound must be greater than the lower bound.</string>
-    <string name="criteria_existed">An identical criteria has already existed.</string>
-    <string name="hint_push_delay">Push delay in minutes</string>
-    <string name="prompt_rank_zero">There is no such rank as 0, the minimum rank is 1.</string>
-    <string name="prompt_max_criteria_count">Too much criteria, please try to remove some and retry.</string>
+    <string name="requires_followed_duelist">Must include a followed player</string>
+    <string name="unlimited_criteria">Invalid criteria: all duels would match.</string>
+    <string name="invalid_rank_range">Upper bound must be ≥ lower bound</string>
+    <string name="criteria_existed">An identical criterion already exists</string>
+    <string name="hint_push_delay">Push (?) minutes after duel starts</string>
+    <string name="prompt_rank_zero">Rank 0 doesn\'t exist; the highest rank is 1.</string>
+    <string name="prompt_max_criteria_count">Too many criteria. Please remove some and try again.</string>
     <string name="manage_tags">Manage tags</string>
     <string name="manage_followed_players">Manage followed players</string>
     <string name="edit_criteria">Edit Push Criteria</string>
     <string name="use_preset">Use preset criteria</string>
     <string name="tagged_players">Tagged Players</string>
-    <string name="tag_new_player">Tag a new player</string>
-    <string name="player_already_tagged">This player has already been tagged</string>
+    <string name="tag_new_player">Add tag for a new player</string>
+    <string name="player_already_tagged">This player is already tagged</string>
     <string name="player_name">Player Name</string>
-    <string name="player_already_followed">This player has already been followed</string>
+    <string name="player_already_followed">Already following this player</string>
     <string name="reload">Reload</string>
     <string name="reload_info">Reload Information</string>
     <string name="leaderboard">Leaderboard</string>
     <string name="in_progress">In progress…</string>
-    <string name="prompt_clear_all_notifications">Do you want to clear all shown notifications?</string>
-    <string name="loaded_successfully">Load Successfully</string>
-    <string name="prompt_load_failed">Load failed. Please try again.</string>
+    <string name="prompt_clear_all_notifications">Clear all shown notifications?</string>
+    <string name="loaded_successfully">Loaded successfully</string>
+    <string name="prompt_load_failed">Load failed. Please reload.</string>
     <string name="loading_leaderboard">Loading leaderboard…</string>
     <string name="service_is_running">Service is running…</string>
     <string name="mine">Mine</string>
@@ -126,33 +131,33 @@
     <string name="duel_points">Duel Points</string>
     <string name="exp">Exp</string>
     <string name="member_since">Member since</string>
-    <string name="pls_login">Please Login</string>
-    <string name="prompt_log_out">Are you sure to log out?</string>
+    <string name="pls_login">Please log in</string>
+    <string name="prompt_log_out">Are you sure you want to log out?</string>
     <string name="start_athletic_match">Start Athletic Match</string>
     <string name="matching">Matching…</string>
     <string name="cancel_matching">Cancel Matching</string>
-    <string name="format_match_duration">Elapsed time %s</string>
-    <string name="format_expected_duration">Expected to take %.2f second(s)</string>
+    <string name="format_match_duration">Elapsed: %s</string>
+    <string name="format_expected_duration">Expected: ~%.2f seconds</string>
     <string name="match_cancelled">Match cancelled</string>
-    <string name="match_successfully">Match successfully! Tap to check details.</string>
-    <string name="tap_to_check_details">Tap to check details</string>
+    <string name="match_successfully">Match found! Tap to view details.</string>
+    <string name="tap_to_check_details">Tap to view duel details</string>
     <string name="refresh_failed">Refresh failed</string>
-    <string name="refresh_successfully">Refresh successfully</string>
+    <string name="refresh_successfully">Refreshed successfully</string>
     <string name="cards_probability_calculator">Hand Probability Calculator</string>
-    <string name="deck_card_count">Deck\'s card count</string>
-    <string name="hand_cards_count">Hand\'s card count</string>
-    <string name="reset_to_def">Rest to default count</string>
-    <string name="edit_card_condition">Edit Single Card Condition</string>
-    <string name="any_card">Any Card</string>
-    <string name="spec_card">Specific Card</string>
-    <string name="any_in_collection">Any card in a specific collection</string>
+    <string name="deck_card_count">Deck size</string>
+    <string name="hand_cards_count">Hand size</string>
+    <string name="reset_to_def">Reset to default</string>
+    <string name="edit_card_condition">Edit card condition</string>
+    <string name="any_card">Any card</string>
+    <string name="spec_card">Specific card</string>
+    <string name="any_in_collection">Any card in a collection</string>
     <string name="specify_count">Specify count</string>
-    <string name="optional_remark">Remark (Optional)</string>
+    <string name="optional_remark">Remark (optional)</string>
 
     <string name="html_push_title" translatable="false"><![CDATA[<b>%s</b>(%d) <i>VS</i> <b>%s</b>(%d)]]></string>
     <string name="html_push_delayed"><![CDATA[Started <b>%d</b> minute(s) ago!]]></string>
-    <string name="format_push_content">A duel you are following is in progress! %s</string>
-    <string name="html_push_content_tagged">"<![CDATA[【<b>%s</b>】A tag-featured duel is in progress! %s]]>"</string>
+    <string name="format_push_content">A duel you follow is in progress! %s</string>
+    <string name="html_push_content_tagged">"<![CDATA[【<b>%s</b>】A duel you follow is in progress! %s]]>"</string>
     <string-array name="one_the_other">
         <item>One</item>
         <item>the other</item>
@@ -162,40 +167,39 @@
     <string name="criteria_condition_or_prefix">Or&#160;</string>
     <string name="format_criteria_prefix">%s player:&#160;</string>
     <string name="format_criteria_rank_range">ranked between [%d, %s%s</string>
-    <string name="criteria_followed">required to be followed</string>
+    <string name="criteria_followed">must be followed</string>
     <string name="criteria_tags">tagged with </string>
     <string name="criteria_separator">,&#160;</string>
     <string name="criteria_end">.&#160;</string>
-    <string name="format_push_delay">Duels will be pushed %d minute(s) after starting</string>
+    <string name="format_push_delay">Duels will be pushed %d minute(s) after they start</string>
 
     <string name="edit_card_count">Edit card count</string>
-    <string name="input_too_large">Your input number is too large</string>
-    <string name="format_input_too_small">Your input is too small, at least %d</string>
-    <string name="not_spec_card">Exclude specific card</string>
-    <string name="not_any_in_collection">Any card out of a specific collection</string>
+    <string name="input_too_large">The value is too large</string>
+    <string name="format_input_too_small">The value is too small (minimum: %d)</string>
+    <string name="not_spec_card">Exclude a specific card</string>
+    <string name="not_any_in_collection">Any card outside a collection</string>
     <string name="format_collection_name">Collection name: %s</string>
     <string name="def_collection_name">Collection 1</string>
-    <string name="format_collection_card_count">Collection card count: %d</string>
-    <string name="edit_collection_name">Edit this collection\'s name</string>
+    <string name="format_collection_card_count">Cards in collection: %d</string>
+    <string name="edit_collection_name">Edit collection name</string>
     <string name="html_undefined"><![CDATA[<i>Undefined</i>]]></string>
-    <string name="prompt_empty_collection_name">You must define the collection name</string>
-    <string name="format_any_in_collection">Any card in %s(%d cards)</string>
+    <string name="prompt_empty_collection_name">Please name the collection</string>
+    <string name="format_any_in_collection">Any card in %s (%d cards)</string>
     <string name="calculate">Calculate</string>
-    <string name="caption_spec_card">This card is required to be unique in your deck</string>
-    <string name="caption_any_card">Any in the remaining cards of your deck, except for those specified
-    or excluded in other conditions</string>
-    <string name="caption_collection">A collection should not share any card with other defined collections</string>
-    <string name="format_unnamed_condition_set">Unnamed Conditions %d</string>
-    <string name="new_one">Create New One</string>
-    <string name="prompt_reach_max_limit">Max count reached</string>
-    <string name="prompt_remove_condition_set">Are you sure to remove this condition set?</string>
-    <string name="format_not_any_in_collection">Any card except for %s(%d cards)</string>
-    <string name="prompt_retain_current">Do you want the new one to retain current conditions?</string>
-    <string name="do_not_retain">Do not retain</string>
-    <string name="format_calculator_result">The probability of ⌈%s⌋</string>
+    <string name="caption_spec_card">This card must appear exactly once in your deck</string>
+    <string name="caption_any_card">Any of the remaining cards in your deck — excluding those already specified or excluded by other conditions</string>
+    <string name="caption_collection">Collections must not share any cards with each other</string>
+    <string name="format_unnamed_condition_set">Unnamed %s</string>
+    <string name="new_one">New condition set</string>
+    <string name="prompt_reach_max_limit">Maximum count reached</string>
+    <string name="prompt_remove_condition_set">Are you sure you want to remove this condition set?</string>
+    <string name="format_not_any_in_collection">Any card except those in %s (%d cards)</string>
+    <string name="prompt_retain_current">Copy current conditions to the new set?</string>
+    <string name="do_not_retain">Don\'t copy</string>
+    <string name="format_calculator_result">Probability of ⌈%s⌋</string>
     <string name="html_detailed_calculator_result"><![CDATA[<b>In decimal</b>: %s <br/>
     <b>In fraction</b>: %s <br/><b>In percent</b>: %s]]></string>
-    <string name="result_not_calculated"><i>(The result is not yet calculated)</i></string>
+    <string name="result_not_calculated"><i>(Not yet calculated)</i></string>
     <string name="details">Details</string>
     <string name="sum">Sum:</string>
     <string name="sum_probability">Probability Sum</string>
@@ -205,131 +209,131 @@
     <b>In fraction</b>: %s <br/>
     <b>In percent</b>: %s]]></string>
     <string name="examples">Examples</string>
-    <string name="prompt_discard_condition_sets">Do you want to discard currently edited condition sets?</string>
+    <string name="prompt_discard_condition_sets">Discard the current condition sets?</string>
 
     <!-- Custom Room -->
-    <string name="room_assist">Custom Game Assistant</string>
+    <string name="room_assist">Custom Room Assistant</string>
     <string name="host_name">Server</string>
     <string name="port">Port</string>
-    <string name="time_per_turn">Duration Per Turn (0–999)</string>
-    <string name="life_points">Life Points (1–99999)</string>
-    <string name="start_draw">Start Draw Count(1–40)</string>
-    <string name="draw_count">Per Draw Count(0–35)</string>
-    <string name="no_fl_list"><![CDATA[No forbidden & limited card list]]></string>
-    <string name="card_pool">Card Pool</string>
+    <string name="time_per_turn">Time per turn (0–999)</string>
+    <string name="life_points">Life points (1–99999)</string>
+    <string name="start_draw">Starting hand size (1–40)</string>
+    <string name="draw_count">Cards drawn per turn (0–35)</string>
+    <string name="no_fl_list"><![CDATA[No forbidden & limited list]]></string>
+    <string name="card_pool">Card pool</string>
     <string name="rule">Rule</string>
-    <string name="no_shuffle">No Deck Shuffle</string>
-    <string name="no_check">No Deck Check</string>
+    <string name="no_shuffle">Don\'t shuffle deck</string>
+    <string name="no_check">Don\'t check deck</string>
     <string name="mode">Mode</string>
-    <string name="remark_turn_duration">When the input turn duration is in 0–60, the unit is minute. Otherwise the unit is second.</string>
-    <string name="create_game_room">Create Game Room</string>
-    <string name="format_error_range">The range is %d to %d</string>
-    <string name="optional_password">Password (Optional)</string>
+    <string name="remark_turn_duration">Values 0–60 are interpreted as minutes; larger values as seconds.</string>
+    <string name="create_game_room">Create room</string>
+    <string name="format_error_range">Valid range: %d to %d</string>
+    <string name="optional_password">Password (optional)</string>
     <string name="copy_room_id">Copy Room ID</string>
     <string name="copied_to_clipboard">Copied to clipboard</string>
-    <string name="download_advance_cards">Download &amp; Install Pre-scripted Cards</string>
+    <string name="download_advance_cards">Download &amp; install advance cards</string>
     <string name="update_history">Update History</string>
     <string name="open_in_browser">Open in Browser</string>
     <string name="download_and_install">Download &amp; Install</string>
     <string name="downloading">Downloading…</string>
     <string-array name="preset_criteria">
-        <item>Containing any followed player</item>
-        <item>Both two players ranked between 1 and 100</item>
-        <item>White-hot duels</item>
+        <item>At least one followed player</item>
+        <item>Both players ranked between 1 and 100</item>
+        <item>Heated duels</item>
     </string-array>
     <string-array name="rules">
         <item>Default</item>
-        <item>Mater Rule 1</item>
-        <item>Mater Rule 2</item>
-        <item>Mater Rule 3</item>
+        <item>Master Rule 1</item>
+        <item>Master Rule 2</item>
+        <item>Master Rule 3</item>
         <item>New Master Rule</item>
         <item>Master Rule 2020</item>
     </string-array>
     <string-array name="modes">
         <item>Single</item>
-        <item>Match</item>
-        <item>TAG</item>
+        <item>Match (best of 3)</item>
+        <item>Tag</item>
     </string-array>
     <string-array name="card_pools">
         <item>Default</item>
-        <item>TCG &amp; OCG (Use OCG F&amp;L List)</item>
-        <item>TCG Only</item>
-        <item>No TCG or OCG Unique Cards</item>
+        <item>TCG + OCG exclusives allowed (uses latest OCG F&amp;L list)</item>
+        <item>TCG only — no OCG exclusives (uses latest TCG F&amp;L list)</item>
+        <item>No TCG or OCG exclusives</item>
     </string-array>
-    <string name="optional_username">Username (Optional)</string>
-    <string name="download_successfully">Download successfully! Start installing…</string>
-    <string name="set_as_home">Set this page as home</string>
-    <string name="cancel_set_as_home">Cancel Set-As-Home</string>
-    <string name="remove_notification">Remove Notification</string>
-    <string name="about_text">This app is <a href='https://github.com/xjunz/MyCard-YGO-Assisant'>open-sourced</a> under <b>Apache-License 2.0</b></string>
-    <string name="check_update">Check For Updates</string>
+    <string name="optional_username">Username (optional)</string>
+    <string name="download_successfully">Download complete. Installing…</string>
+    <string name="set_as_home">Set as home page</string>
+    <string name="cancel_set_as_home">Unset as home page</string>
+    <string name="remove_notification">Remove notification</string>
+    <string name="about_text">This app is <a href='https://github.com/xjunz/MyCard-YGO-Assisant'>open-sourced</a> under <b>Apache-License 2.0</b>.\n\nIf you find it useful, you can tap ⌈Donate⌋ below to support my work.</string>
+    <string name="check_update">Check for updates</string>
     <string name="donate">Donate</string>
-    <string name="version_info">Version Info</string>
-    <string name="credits">Special thanks to <b>YGO Mobile</b> &amp; <a href='https://mycard.moe/'>MyCard</a></string>
-    <string name="has_updates">New Version Found</string>
+    <string name="version_info">Version info</string>
+    <string name="credits">Special thanks to <b>YGO Mobile</b> and the <a href='https://mycard.moe/'>MyCard</a> team.</string>
+    <string name="has_updates">Update available</string>
     <string name="html_updates_info">
-        <![CDATA[<b>Version Name: </b>%s<br/><br/>
-        <b>File Size: </b>%s<br/><br/>
-        <b>What\'s New: </b>%s]]>
+        <![CDATA[<b>Version: </b>%s<br/><br/>
+        <b>Size: </b>%s<br/><br/>
+        <b>What\'s new: </b>%s]]>
     </string>
     <string name="download">Download</string>
     <string name="check_update_failed">Failed to check for updates</string>
-    <string name="feedback_join_group"><![CDATA[Feedback & Join Group]]></string>
-    <string name="choose_a_way_to_feedback">Choose a way to feedback</string>
+    <string name="feedback_join_group"><![CDATA[Feedback & discussion group]]></string>
+    <string name="choose_a_way_to_feedback">Choose a feedback method</string>
     <string name="format_mail_subject">「MyCard YGO Assistant」Feedback - %s</string>
-    <string name="no_way_to_open">No app to handle this request</string>
-    <string name="no_new_version">No new version is found</string>
+    <string name="no_way_to_open">No app available to handle this</string>
+    <string name="no_new_version">You\'re on the latest version</string>
     <string name="edit_collection">Edit this collection</string>
-    <string name="duel_history">Duel History</string>
-    <string name="format_history">\'s Duel History</string>
-    <string name="format_duel_duration">Started at: %s \nEnded at: %s\nDuration: %s</string>
+    <string name="duel_history">Duel history</string>
+    <string name="format_history">\'s duel history</string>
+    <string name="format_duel_duration">Started: %s\nEnded: %s\nDuration: %s</string>
     <string name="win">W</string>
     <string name="lose">L</string>
-    <string name="search">search</string>
-    <string name="search_for_player">Search players</string>
-    <string name="input_player_name">Input a player name</string>
+    <string name="search">Search</string>
+    <string name="search_for_player">Find a player</string>
+    <string name="input_player_name">Enter a username</string>
     <string-array name="error_feedback_ways">
         <item>Email</item>
-        <item>Tencent QQ™ Group</item>
-        <item>Others</item>
+        <item>QQ feedback group</item>
+        <item>Other</item>
     </string-array>
     <string-array name="feedback_ways">
         <item>Email</item>
-        <item>Tencent QQ™ Group</item>
+        <item>QQ feedback group</item>
     </string-array>
-    <string name="chart_legend_desc">D.P changes in latest %d duels</string>
-    <string name="chart_desc">*Try tapping or pinching the chart</string>
+    <string name="chart_legend_desc">D.P changes over the last %d duels</string>
+    <string name="chart_desc">*Try tapping or pinch-zooming the chart</string>
     <string name="first_win">(First Win)</string>
-    <string name="tip_show_player_info">Tap the player name to show player info!</string>
-    <string name="filter_and_sort">Filter &amp; Sort</string>
-    <string name="min_duel_duration">Min duel duration in minute</string>
+    <string name="tip_show_player_info">Tap a player name to view their info!</string>
+    <string name="filter_and_sort">Filter &amp; sort</string>
+    <string name="min_duel_duration">Duel running for at least (?) minutes</string>
     <string name="reset">Reset</string>
     <string name="sort_by">Sort by</string>
     <string name="order">Order</string>
-    <string name="tip_no_duel_matches_filter">No duel matches current filter.</string>
-    <string name="tip_filter_and_sort">Tap here to filter or sort current duel list!</string>
-    <string name="unfollow_all">Clear all following players</string>
-    <string name="prompt_unfollow_all_players">Are you sure to unfollow all players?</string>
+    <string name="tip_no_duel_matches_filter">No duels match the current filter</string>
+    <string name="tip_filter_and_sort">Tap here to sort and filter the duel list!</string>
+    <string name="unfollow_all">Unfollow all players</string>
+    <string name="prompt_unfollow_all_players">Are you sure you want to unfollow all players?</string>
     <string name="clear_all_tags">Clear all tags</string>
-    <string name="prompt_remove_all_tags">Are you sure to remove all tags?</string>
+    <string name="prompt_remove_all_tags">Are you sure you want to remove all tags?</string>
     <string name="player_key_word">Player keyword</string>
-    <string name="tip_return_to_top">Back to top</string>
-    <string name="tip_back_to_top">Tap to return to the top of list!</string>
-    <string name="delete_tag_for_all_players">Delete a specific tag for all players</string>
-    <string name="format_prompt_delete_tag">Are you sure to delete tag "%s" for all players?</string>
-    <string name="query_history_count">Historical duel count</string>
+    <string name="tip_return_to_top">Back at the top</string>
+    <string name="tip_back_to_top">Tap to scroll back to the top!</string>
+    <string name="delete_tag_for_all_players">Remove a tag from all players</string>
+    <string name="format_prompt_delete_tag">Are you sure you want to remove tag \"%s\" from all players?</string>
+    <string name="query_history_count">Duels to query</string>
     <string name="close">Close</string>
     <string-array name="duel_list_sort_by">
         <item>Duel start time (default)</item>
-        <item>Best rank in both players</item>
-        <item>Rank sum of both players</item>
-        <item>Rank difference between both players</item>
-        <item>Best win rate in both players</item>
-        <item>Win rate sum of both players</item>
-        <item>Win rate difference between both players</item>
+        <item>Higher rank between players</item>
+        <item>Sum of both players\' ranks</item>
+        <item>Difference between players\' ranks</item>
+        <item>Higher win rate between players</item>
+        <item>Sum of both players\' win rates</item>
+        <item>Difference between players\' win rates</item>
     </string-array>
     <string-array name="orders">
-        <item>Ascend</item>
-        <item>Descend</item>
+        <item>Ascending</item>
+        <item>Descending</item>
     </string-array>
 </resources>


### PR DESCRIPTION
## Summary
- First-time YGOMobile onboarding dialog gates spectate launches behind a one-time check, sidestepping YGOMobile's `ResCheckTask` race that otherwise leaves a black screen on cold start. Dismissal is keyed to `PackageInfo.firstInstallTime` so reinstalls re-arm the hint.
- Dismissible spectate hint header above the duel list, gated on the dialog having been read + user not dismissed + duel list loaded. RV `paddingTop` syncs with `topBar` height during the layout pass so cards never overlap the first row.
- Eager-init `AccountManager` in `App.onCreate`, fixing first-install crash where `LeaderboardFragment` rendered before `DuelMonitorService` bound. Also migrates v2.4 users (whose bearer token wasn't persisted) by forcing re-login.
- Naturalize English `strings.xml`: typo fixes (Mater Rule → Master Rule, Rest → Reset), drop "Are you sure to X" pattern across 8 prompts, sync recently-rewritten ZH strings, restore the donate sentence in `about_text`.

## Test plan
- [ ] Fresh install → no AccountManager crash; LeaderboardFragment renders.
- [ ] First spectate after fresh YGOMobile install shows onboarding dialog; "Open YGOMobile first" persists dismissal; "Spectate anyway" does not.
- [ ] Reinstall YGOMobile → onboarding dialog re-arms.
- [ ] After reading the dialog, hint header appears above the duel list once loaded; never overlaps the first item; close button dismisses persistently.
- [ ] v2.4 → v2.6 upgrade path with logged-in user forces re-login (no orphaned auth state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)